### PR TITLE
Fix persona endpoint logic and update DB config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,14 @@ Este proyecto está diseñado para el **Sistema Integrado de Salud** con el fin 
 
 ## ⚙️ Uso
 
-* **Endpoint base**: `http://localhost:8080/api/fuas`
+* **Endpoint base**: `http://localhost:8080/api/personas`
 * **Documentación interactiva (Swagger UI)**: `http://localhost:8080/swagger-ui.html`
 
 **Pruebas con Postman**:
 
-1. Importar la colección `postman_collection.json` (incluida en el repositorio).
-2. Ejecutar los requests para crear, leer, actualizar y eliminar FUAS.
+1. Ejecuta la aplicación con `mvn spring-boot:run`.
+2. Envía una petición GET a `http://localhost:8080/api/personas` para obtener todas las personas.
+3. Para paginar, usa `http://localhost:8080/api/personas/paginate?page=0&size=10`.
 
 ---
 

--- a/src/main/java/pe/com/red/sis/red_sis/aplication/service/PersonaService.java
+++ b/src/main/java/pe/com/red/sis/red_sis/aplication/service/PersonaService.java
@@ -1,9 +1,9 @@
 package pe.com.red.sis.red_sis.aplication.service;
 
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
 import pe.com.red.sis.red_sis.aplication.ports.input.PersonaUseCase;
 import pe.com.red.sis.red_sis.aplication.ports.output.PersonaRepositoryPort;
 import pe.com.red.sis.red_sis.domian.models.response.PersonaResponse;
@@ -11,6 +11,7 @@ import pe.com.red.sis.red_sis.domian.models.response.PersonaResponse;
 import java.util.List;
 
 @RequiredArgsConstructor
+@Service
 public class PersonaService implements PersonaUseCase {
 
     private final PersonaRepositoryPort personaRepositoryPort;

--- a/src/main/java/pe/com/red/sis/red_sis/infrastructure/controller/PersonaController.java
+++ b/src/main/java/pe/com/red/sis/red_sis/infrastructure/controller/PersonaController.java
@@ -1,6 +1,7 @@
 package pe.com.red.sis.red_sis.infrastructure.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +12,7 @@ import pe.com.red.sis.red_sis.aplication.ports.input.PersonaUseCase;
 import pe.com.red.sis.red_sis.domian.models.response.ApiResponse;
 import pe.com.red.sis.red_sis.domian.models.response.Paginate;
 import pe.com.red.sis.red_sis.domian.models.response.PersonaResponse;
+import pe.com.red.sis.red_sis.infrastructure.repository.mapper.PaginateMapper;
 
 import java.util.List;
 
@@ -20,6 +22,7 @@ import java.util.List;
 public class PersonaController {
 
     private final PersonaUseCase personaUseCase;
+    private final PaginateMapper paginateMapper;
 
     @GetMapping
     public ApiResponse<List<PersonaResponse>> listAll() {
@@ -33,8 +36,9 @@ public class PersonaController {
             @RequestParam(defaultValue = "10") int size
     ) {
         Pageable pageable = PageRequest.of(page, size);
-        Paginate meta = (Paginate) personaUseCase.getPagination("", pageable);
-        List<PersonaResponse> data = personaUseCase.getList();
+        Page<PersonaResponse> pageResult = personaUseCase.getPagination("", pageable);
+        List<PersonaResponse> data = pageResult.getContent();
+        Paginate meta = paginateMapper.toPaginate(pageResult);
         return ApiResponse.of(data, meta);
     }
 

--- a/src/main/java/pe/com/red/sis/red_sis/infrastructure/repository/adapter/PersonaRepositoryAdapter.java
+++ b/src/main/java/pe/com/red/sis/red_sis/infrastructure/repository/adapter/PersonaRepositoryAdapter.java
@@ -5,7 +5,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import pe.com.red.sis.red_sis.aplication.ports.output.PersonaRepositoryPort;
-import pe.com.red.sis.red_sis.domian.models.response.Paginate;
 import pe.com.red.sis.red_sis.domian.models.response.PersonaResponse;
 import pe.com.red.sis.red_sis.infrastructure.repository.entities.PersonaEntity;
 import pe.com.red.sis.red_sis.infrastructure.repository.jpa.PersonaJpaRepository;
@@ -33,15 +32,8 @@ public class PersonaRepositoryAdapter implements PersonaRepositoryPort {
 
     @Override
     public Page<PersonaResponse> getPagination(String search, Pageable pageable) {
-        Page<PersonaEntity> page = personaJpaRepository.findAll(pageable);
-        List<PersonaResponse> content = page.getContent().stream()
-                .map(personaMapper::toResponse)
-                .collect(Collectors.toList());
-        Paginate meta = paginateMapper.toPaginate(page);
-        return (Page<PersonaResponse>) Paginate.builder()
-                .currentPage(meta.getCurrentPage())
-                .totalPages(meta.getTotalPages())
-                .totalElements(meta.getTotalElements())
-                .build();
+        return personaJpaRepository
+                .findAll(pageable)
+                .map(personaMapper::toResponse);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,15 +1,16 @@
-# Nombre de la aplicación
+# Nombre de la aplicaciÃ³n
 spring.application.name=red-sis
 
-# Configuración SQL Server con autenticación Windows
-spring.datasource.url=jdbc:sqlserver://PC02-SIS;instanceName=SQLEXPRESS;databaseName=dbSIS;integratedSecurity=true;encrypt=true;trustServerCertificate=true
-spring.datasource.username=usuario_sis
-spring.datasource.password=
-
-# Driver JDBC (no especificar usuario/contraseña)
+# URL correcta para SQL Server
+spring.datasource.url=jdbc:sqlserver://localhost:1433;databaseName=dbSIS
+spring.datasource.username=sa
+spring.datasource.password=admin123
 spring.datasource.driver-class-name=com.microsoft.sqlserver.jdbc.SQLServerDriver
 
-# Configuración JPA/Hibernate
+# JPA/Hibernate
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.SQLServerDialect
+
+# Mostrar errores en la respuesta
+server.error.include-message=always


### PR DESCRIPTION
## Summary
- configure SQL Server access with user credentials
- register `PersonaService` as a `@Service`
- correct repository adapter and controller pagination logic
- document how to call the endpoints with Postman

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/... because the container lacks internet access)*

------
https://chatgpt.com/codex/tasks/task_e_68701129a420832b9135fb3868b82399